### PR TITLE
feat: add REPL run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This plugin allows code blocks to be executed interactively like in Jupyter Note
 It has no external environment requirements (such as system installations of compilers), because code execution works via local sandboxes using JavaScript or WebAssembly technology, or network requests to online Playgrounds.
 This means it can support all platforms supported by Obsidian.
 
+An extra run button is available to launch code in a simple REPL mode so programs can request user input until they finish running.
+
 Supports all Obsidian supported platforms, including:
 
 - Windows

--- a/src/backend/languages/python.ts
+++ b/src/backend/languages/python.ts
@@ -52,7 +52,8 @@ export default (function(props?: { cdn: string }) {
     engine = await loader({
       indexURL: cdn,
       stdout: (s) => stdio?.stdout(s),
-      stderr:(s) => stdio?.stderr(s)
+      stderr:(s) => stdio?.stderr(s),
+      stdin: () => stdio?.read() ?? ''
     });
     await engine.loadPackage('micropip');
     console.log('python loaded.');

--- a/src/backend/store.ts
+++ b/src/backend/store.ts
@@ -4,6 +4,14 @@ export type Stdio = ReturnType<typeof createStdio>;
 export function createStdio<T = Message>() {
   let outputs: T[] = [];
   let subscribers: ((m: T[]) =>  void)[] = [];
+  let interactive = false;
+
+  const setInteractive = (v: boolean) => { interactive = v; };
+
+  const read = (msg?: string): string => {
+    if (!interactive) { return ''; }
+    return window.prompt(msg ?? '') ?? '';
+  };
   
   const update = (setter: (prev: T[]) => T[]) => {
     outputs = setter(outputs);
@@ -49,5 +57,7 @@ export function createStdio<T = Message>() {
     clear,
     update,
     set,
+    read,
+    setInteractive,
   };
 }

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -6,6 +6,9 @@ const icons = {
   </svg>,
   play: () => <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="0.75em" height="1em" viewBox="0 0 384 512">
     <path fill="currentColor" d="M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80v352c0 17.4 9.4 33.4 24.5 41.9S58.2 482 73 473l288-176c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41z"/>
+  </svg>,
+  repl: () => <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="0.75em" height="1em" viewBox="0 0 576 512">
+    <path fill="currentColor" d="M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416l288 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-288 0c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/>
   </svg>
 }
 

--- a/src/components/Play.scss
+++ b/src/components/Play.scss
@@ -1,5 +1,6 @@
 :global {
-  pre:hover .button-play {
+  pre:hover .button-play,
+  pre:hover .button-repl {
     display: block;
   }
 }
@@ -11,18 +12,22 @@
 
 .code-emitter-block {
 
-  .button-play {
+  .button-play,
+  .button-repl {
     bottom: var(--size-2-2);
     display: flex;
 
     padding: var(--size-2-2) var(--size-2-3);
     position: absolute;
-    inset-inline-end: var(--size-2-2);
     border-radius: var(--radius-s);
     cursor: var(--cursor);
   }
 
-  .button-play:hover {
+  .button-play { inset-inline-end: var(--size-2-2); }
+  .button-repl { inset-inline-end: calc(var(--size-2-2) + 2.5em); }
+
+  .button-play:hover,
+  .button-repl:hover {
     background-color: var(--background-modifier-hover);
   }
 

--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -30,15 +30,20 @@ export default (props: {
 
   const [running, setRunning] = createSignal(false);
 
-  const run = async () => {
+  const run = async (interactive: boolean) => {
     setRunning(true);
+    stdio.setInteractive(interactive);
     try {
       const engine = backend[props.lang];
       await engine(props.code, stdio);
     } finally {
       setRunning(false);
+      stdio.setInteractive(false);
     }
   };
+
+  const runNormal = () => run(false);
+  const runRepl = () => run(true);
 
 
   const readFromCache = () => {
@@ -68,7 +73,7 @@ export default (props: {
     if (r) {
       stdio.set(r);
     } else if (props.autoRun) {
-      await run();
+      await runNormal();
     }
   });
 
@@ -77,7 +82,10 @@ export default (props: {
   return <>
     <div class="code-emitter-block solid">
       <Show when={ !running() && !hasResult()}>
-        <i aria-label="play" class="button-play" onClick={run}><Icon name="play"/></i>
+        <>
+          <i aria-label="play" class="button-play" onClick={runNormal}><Icon name="play"/></i>
+          <i aria-label="repl" class="button-repl" onClick={runRepl}><Icon name="repl"/></i>
+        </>
       </Show>
 
       <Show when={running() || hasResult() }>


### PR DESCRIPTION
## Summary
- add REPL run button with terminal icon
- support interactive stdin in Stdio and Python backend
- document new REPL mode in README

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Duplicate index signature for type 'number', missing DataAdapter methods)*


------
https://chatgpt.com/codex/tasks/task_e_68b966b2d5cc83249ad72bfa7a45d5c0