### PR TITLE
Add Python REPL run option

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -6,7 +6,7 @@ export type { Stdio } from './store';
 
 export type Backend = {
     loading?: boolean;
-    (code: string, output: Stdio): Promise<void>
+    (code: string, output: Stdio, opts?: { repl?: boolean }): Promise<void>
 }
 
 

--- a/src/backend/languages/python.ts
+++ b/src/backend/languages/python.ts
@@ -42,7 +42,10 @@ export default (function(props?: { cdn: string }) {
           if (promptText) {
             output.stdout(promptText);
           }
-          const result = window.prompt(promptText ?? '') ?? '';
+          const result =
+            typeof window !== 'undefined' && typeof window.prompt === 'function'
+              ? window.prompt(promptText ?? '') ?? ''
+              : '';
           output.stdout(result);
           return result;
         };

--- a/src/backend/languages/python.ts
+++ b/src/backend/languages/python.ts
@@ -29,14 +29,41 @@ export default (function(props?: { cdn: string }) {
   let engine: PyodideInterface | null = null;
   let stdio: Stdio | null = null;
   let load: (() => Promise<void>) | null = null;
-  const backend: Backend = async (code, output) => {
+  const backend: Backend = async (code, output, opts) => {
     if (!engine) {
       await load();
     }
     stdio = output;
     try {
       setMplTarget(output.viewEl);
-      await engine.runPythonAsync(code);
+      if (opts?.repl) {
+        const g = globalThis as { console_input?: (promptText?: string) => string };
+        g.console_input = (promptText?: string) => {
+          if (promptText) {
+            output.stdout(promptText);
+          }
+          const result = window.prompt(promptText ?? '') ?? '';
+          output.stdout(result);
+          return result;
+        };
+        await engine.runPythonAsync(`
+import builtins, js
+__orig_input = builtins.input
+builtins.input = js.console_input
+`);
+        try {
+          await engine.runPythonAsync(code);
+        } finally {
+          await engine.runPythonAsync(`
+import builtins
+builtins.input = __orig_input
+del __orig_input
+`);
+          delete g.console_input;
+        }
+      } else {
+        await engine.runPythonAsync(code);
+      }
     } catch (e) {
       output.stderr(e);
     } finally {

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -6,6 +6,9 @@ const icons = {
   </svg>,
   play: () => <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="0.75em" height="1em" viewBox="0 0 384 512">
     <path fill="currentColor" d="M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80v352c0 17.4 9.4 33.4 24.5 41.9S58.2 482 73 473l288-176c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41z"/>
+  </svg>,
+  terminal: () => <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="0.75em" height="1em" viewBox="0 0 576 512">
+    <path fill="currentColor" d="M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416l288 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-288 0c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/>
   </svg>
 }
 

--- a/src/components/Play.scss
+++ b/src/components/Play.scss
@@ -1,5 +1,6 @@
 :global {
-  pre:hover .button-play {
+  pre:hover .button-play,
+  pre:hover .button-repl {
     display: block;
   }
 }
@@ -20,6 +21,20 @@
     inset-inline-end: var(--size-2-2);
     border-radius: var(--radius-s);
     cursor: var(--cursor);
+  }
+
+  .button-repl {
+    bottom: var(--size-2-2);
+    display: flex;
+    padding: var(--size-2-2) var(--size-2-3);
+    position: absolute;
+    inset-inline-end: calc(var(--size-2-2) + 2em);
+    border-radius: var(--radius-s);
+    cursor: var(--cursor);
+  }
+
+  .button-repl:hover {
+    background-color: var(--background-modifier-hover);
   }
 
   .button-play:hover {

--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -30,11 +30,11 @@ export default (props: {
 
   const [running, setRunning] = createSignal(false);
 
-  const run = async () => {
+  const run = async (repl = false) => {
     setRunning(true);
     try {
       const engine = backend[props.lang];
-      await engine(props.code, stdio);
+      await engine(props.code, stdio, { repl });
     } finally {
       setRunning(false);
     }
@@ -77,7 +77,10 @@ export default (props: {
   return <>
     <div class="code-emitter-block solid">
       <Show when={ !running() && !hasResult()}>
-        <i aria-label="play" class="button-play" onClick={run}><Icon name="play"/></i>
+        <i aria-label="play" class="button-play" onClick={() => run(false)}><Icon name="play"/></i>
+        <Show when={props.lang === 'python'}>
+          <i aria-label="repl" class="button-repl" onClick={() => run(true)}><Icon name="terminal"/></i>
+        </Show>
       </Show>
 
       <Show when={running() || hasResult() }>


### PR DESCRIPTION
## Summary
- Add a REPL run button with a terminal icon for Python code blocks to accept user input interactively
- Extend the backend interface and Python engine to support a `repl` option that captures inputs via prompts
- Style new REPL button alongside the existing run button

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b97dcaa9dc83248d25bf3c4d8fb366